### PR TITLE
Update extension_script.rst

### DIFF
--- a/docs/extension_script.rst
+++ b/docs/extension_script.rst
@@ -70,4 +70,4 @@ See this in action in the “Error Demo” section of the :doc:`example project 
 
 .. hint::
 
-   This extension script should not be confused with htmx’s `debug extension <https://htmx.org/extensions/debug/>`__, which logs DOM events in the browser console.
+   This extension script should not be confused with htmx’s `debug extension <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md>`__, which logs DOM events in the browser console.


### PR DESCRIPTION
The link was dead, but since v2 came out HTMX no longer references to their own extensions, but rather to a github. 

Tried to link to the similar copy of https://v1.htmx.org/extensions/debug/ -- which is the github, but for PR -- Might want to link to 

https://htmx.org/extensions/